### PR TITLE
Added packages config to main project

### DIFF
--- a/src/uShip.Logging/packages.config
+++ b/src/uShip.Logging/packages.config
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+</packages>


### PR DESCRIPTION
Adding packages.config since it is needed for appveyor for "nuget
restore" command. Surely nuget packages will be eventually added to this
project anyway (e.g. NLog), so just adding such preemptively.
