### PR TITLE
adding nuspec file for appveyor test.

### DIFF
--- a/src/uShip.Logging/uShip.Logging.nuspec
+++ b/src/uShip.Logging/uShip.Logging.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>uShip Logging</title>
+    <authors>
+      Stephen Guerra, Evan Jones, Troy Miller, Jordan Piedt, Ivan Valle, Ed Vinyard, Jake Wilke
+    </authors>
+    <owners>uSHip, Inc.</owners>
+    <licenseUrl>https://github.com/uShip/uShip.Logging/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/uShip/uShip.Logging</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>$description$</description>
+    <releaseNotes>Experimental release.  Not intended for production use (yet).</releaseNotes>
+    <copyright>Copyright 2015 uShip, Inc.</copyright>
+  </metadata>
+</package>


### PR DESCRIPTION
We need a nuspec file for nuget pack to succeed on appveyor.  I'm just adding this nuspec file for the main uShip.Logging.sln right now.
