### PR TITLE
Slimming nuget dependencies

### DIFF
--- a/src/uShip.Logging/Appender/ApiErrorLogAppender.cs
+++ b/src/uShip.Logging/Appender/ApiErrorLogAppender.cs
@@ -1,10 +1,10 @@
-﻿using FubuCore;
-using log4net.Appender;
+﻿using log4net.Appender;
 using log4net.Core;
 using Newtonsoft.Json;
 using System;
 using System.Net.Http;
 using System.Text;
+using uShip.Logging.Extensions;
 
 namespace uShip.Logging.Appender
 {

--- a/src/uShip.Logging/Appender/ExceptionFormatter.cs
+++ b/src/uShip.Logging/Appender/ExceptionFormatter.cs
@@ -1,7 +1,7 @@
-﻿using FubuCore;
-using log4net.Core;
+﻿using log4net.Core;
 using System;
 using System.Globalization;
+using uShip.Logging.Extensions;
 using uShip.Logging.LogBuilders;
 
 namespace uShip.Logging.Appender

--- a/src/uShip.Logging/ExceptionFormatter.cs
+++ b/src/uShip.Logging/ExceptionFormatter.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 using System.Xml;
-using FubuCore;
+using uShip.Logging.Extensions;
 using uShip.Logging.LogBuilders;
 
 namespace uShip.Logging

--- a/src/uShip.Logging/FubuCoreExtensions/ObjectExtensions.cs
+++ b/src/uShip.Logging/FubuCoreExtensions/ObjectExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace uShip.Logging.Extensions
+{
+    internal static class ObjectExtensions
+    {
+        /// <remarks>https://github.com/DarthFubuMVC/fubucore/blob/master/src/FubuCore/BasicExtensions.cs</remarks>
+        internal static TOut IfNotNull<TTarget, TOut>(this TTarget target, Func<TTarget, TOut> valueFunc)
+            where TTarget : class
+        {
+            return target == null ? default(TOut) : valueFunc(target);
+        }
+    }
+}

--- a/src/uShip.Logging/FubuCoreExtensions/StackFrameExtensions.cs
+++ b/src/uShip.Logging/FubuCoreExtensions/StackFrameExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System.Diagnostics;
+
+namespace uShip.Logging.Extensions
+{
+    internal static class StackFrameExtensions
+    {
+        internal static string ToDescription(this StackFrame frame)
+        {
+            return string.Format("{0}.{1}(), {2} line {3}",
+                frame.GetMethod().DeclaringType.FullName,
+                frame.GetMethod().Name,
+                frame.GetFileName(),
+                frame.GetFileLineNumber());
+        }
+    }
+}

--- a/src/uShip.Logging/FubuCoreExtensions/StreamExtensions.cs
+++ b/src/uShip.Logging/FubuCoreExtensions/StreamExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System.IO;
+
+namespace uShip.Logging.Extensions
+{
+    internal static class StreamExtensions
+    {
+        internal static string ReadAllText(this Stream stream)
+        {
+            var reader = new StreamReader(stream);
+            return reader.ReadToEnd();
+        }
+    }
+}

--- a/src/uShip.Logging/FubuCoreExtensions/license.txt
+++ b/src/uShip.Logging/FubuCoreExtensions/license.txt
@@ -1,0 +1,16 @@
+﻿From: https://github.com/DarthFubuMVC/fubucore/blob/master/license.txt
+
+Copyright 2011 Jeremy Miller, Chad Myers, Joshua Flanagan, Robert Greyling, Joshua Arnold, Brandon Behrens, and Josh Arnold
+Copyright 2009-2010 Chad Myers, Jeremy Miller, Joshua Flanagan, Mark Nijhof
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/uShip.Logging/LogBuilders/Log4NetErrorHandler.cs
+++ b/src/uShip.Logging/LogBuilders/Log4NetErrorHandler.cs
@@ -1,10 +1,10 @@
-using FubuCore;
 using log4net.Core;
 using Newtonsoft.Json;
 using System;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
+using uShip.Logging.Extensions;
 
 namespace uShip.Logging.LogBuilders
 {

--- a/src/uShip.Logging/LogBuilders/Logger.cs
+++ b/src/uShip.Logging/LogBuilders/Logger.cs
@@ -1,8 +1,8 @@
-﻿using FubuCore;
-using log4net;
+﻿using log4net;
 using log4net.Config;
 using System;
 using System.Text;
+using uShip.Logging.Extensions;
 using uShip.Logging.LogBuilders;
 
 namespace uShip.Logging

--- a/src/uShip.Logging/LogBuilders/LoggingEventPropertiesBuilder.cs
+++ b/src/uShip.Logging/LogBuilders/LoggingEventPropertiesBuilder.cs
@@ -1,5 +1,4 @@
-﻿using FubuCore;
-using log4net.Util;
+﻿using log4net.Util;
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/uShip.Logging/packages.config
+++ b/src/uShip.Logging/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="JetBrains.Annotations" version="10.0.0" targetFramework="net45" />
+  <package id="JetBrains.Annotations" version="10.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="log4net" version="2.0.5" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>

--- a/src/uShip.Logging/packages.config
+++ b/src/uShip.Logging/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FubuCore" version="2.0.0.311" targetFramework="net45" />
   <package id="JetBrains.Annotations" version="10.0.0" targetFramework="net45" />
   <package id="log4net" version="2.0.5" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />

--- a/src/uShip.Logging/uShip.Logging.csproj
+++ b/src/uShip.Logging/uShip.Logging.csproj
@@ -36,10 +36,6 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FubuCore, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\FubuCore.2.0.0.311\lib\FubuCore.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="JetBrains.Annotations, Version=10.0.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
       <HintPath>..\packages\JetBrains.Annotations.10.0.0\lib\net20\JetBrains.Annotations.dll</HintPath>
       <Private>True</Private>
@@ -72,7 +68,11 @@
     <Compile Include="Appender\ApiErrorLogAppender.cs" />
     <Compile Include="ConfiguredLogger.cs" />
     <Compile Include="Extensions\HttpRequestExtensions.cs" />
+    <Content Include="FubuCoreExtensions\license.txt" />
+    <Compile Include="FubuCoreExtensions\ObjectExtensions.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
+    <Compile Include="FubuCoreExtensions\StackFrameExtensions.cs" />
+    <Compile Include="FubuCoreExtensions\StreamExtensions.cs" />
     <Compile Include="IFluentLogger.cs" />
     <Compile Include="IFluentLoggerWriter.cs" />
     <Compile Include="IGraphiteKey.cs" />

--- a/src/uShip.Logging/uShip.Logging.nuspec
+++ b/src/uShip.Logging/uShip.Logging.nuspec
@@ -14,7 +14,6 @@
     <copyright>Copyright 2015 uShip, Inc.</copyright>
     <tags>uShip.com, uShip, uShip.Logging</tags>
     <dependencies>
-        <dependency id="JetBrains.Annotations" version="10.0.0" />
         <dependency id="Newtonsoft.Json" version="7.0.1" />
         <dependency id="log4net" version="2.0.5"  />
     </dependencies>

--- a/src/uShip.Logging/uShip.Logging.nuspec
+++ b/src/uShip.Logging/uShip.Logging.nuspec
@@ -14,7 +14,6 @@
     <copyright>Copyright 2015 uShip, Inc.</copyright>
     <tags>uShip.com, uShip, uShip.Logging</tags>
     <dependencies>
-        <dependency id="FubuCore" version="1.0.0.311"  />
         <dependency id="JetBrains.Annotations" version="10.0.0" />
         <dependency id="Newtonsoft.Json" version="7.0.1" />
         <dependency id="log4net" version="2.0.5"  />

--- a/src/uShip.Logging/uShip.Logging.nuspec
+++ b/src/uShip.Logging/uShip.Logging.nuspec
@@ -12,7 +12,7 @@
     <description>$description$</description>
     <releaseNotes>Experimental release.  Not intended for production use (yet).</releaseNotes>
     <copyright>Copyright 2015 uShip, Inc.</copyright>
-    <tags>uShip.com, uShip, uShip.Logging</tags>
+    <tags>uShip.com, uShip, uShip.Logging, logstash, graphite</tags>
     <dependencies>
         <dependency id="Newtonsoft.Json" version="7.0.1" />
         <dependency id="log4net" version="2.0.5"  />


### PR DESCRIPTION
Found that the library only uses 3 methods from FubuCore, but FubuCore adds a large number of extensions and classes, including a `Logger` class.

So this pull request removes the fubucore dependency, and instead copies the code for the 3 methods being used here into the codebase, and marking them `internal` so that they won't interfere with projects referencing this.

Other possible thoughts to consider:
- Two of the methods are used in a single place, and are 2 line methods themselves.  So instead of keeping them Extension methods, could just put the code into the usage.
- Thought about keeping them as extensions, but in a class `FubuCoreExtensions.cs` to make the source of them extra clear (instead of just being in a folder named such).
