### PR TITLE
Add simple reflective .Data(prefix, object) capability to our fluent logger.

### DIFF
--- a/src/uShip.Logging.Tests/FluentLoggerDataBuilderTestscs.cs
+++ b/src/uShip.Logging.Tests/FluentLoggerDataBuilderTestscs.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace uShip.Logging.Tests
+{
+    [TestFixture]
+    public class FluentLoggerDataBuilderTestscs
+    {
+        private Logger.FluentLogDataBuilder ClassUnderTest { get; set; }
+
+        [SetUp]
+        public void InitDataDictionary()
+        {
+            //reinit the class, assuring a fresh FluentLogDataBuilder each test.
+            ClassUnderTest = new Logger.FluentLogDataBuilder(null, null);
+        }
+
+        [Test]
+        public void Can_map_object_with_primitives()
+        {
+            string testString = "test";
+            int testInt = 32;
+            long testLong = 64L;
+            double testDouble = (double) 2.0;
+            float testFloat = (float)3.0;
+
+            var obj = new
+            {
+                StringProp = testString,
+                IntegerProp = testInt,
+                LongProp = testLong,
+                DoubleProp = testDouble,
+                FloatProp = testFloat                                          
+            };
+            ClassUnderTest.Data(obj);
+            var objName = obj.GetType().Name + "_";
+            Assert.AreEqual(ClassUnderTest._data[objName + "StringProp"], testString);
+            Assert.AreEqual(ClassUnderTest._data[objName + "IntegerProp"], testInt);
+            Assert.AreEqual(ClassUnderTest._data[objName + "LongProp"], testLong);
+            Assert.AreEqual(ClassUnderTest._data[objName + "DoubleProp"], testDouble);
+            Assert.AreEqual(ClassUnderTest._data[objName + "FloatProp"], testFloat);
+            ClassUnderTest._data.Count.Should().Be(5);
+        }
+
+        [Test]
+        public void Can_map_object_with_complex_types()
+        {
+            string testString = "test";
+            int testInt = 32;
+            long testLong = 64L;
+            double testDouble = (double)2.0;
+            float testFloat = (float)3.0;
+
+            var obj = new
+            {
+                StringProp = testString,
+                IntegerProp = testInt,
+                LongProp = testLong,
+                DoubleProp = testDouble,
+                FloatProp = testFloat,
+                ComplexClass = new {
+                    NestedProperty = "Oh no!"
+                }
+            };
+            ClassUnderTest.Data(obj);
+            var objName = obj.GetType().Name + "_";
+            Assert.AreEqual(ClassUnderTest._data[objName + "StringProp"], testString);
+            Assert.AreEqual(ClassUnderTest._data[objName + "IntegerProp"], testInt);
+            Assert.AreEqual(ClassUnderTest._data[objName + "LongProp"], testLong);
+            Assert.AreEqual(ClassUnderTest._data[objName + "DoubleProp"], testDouble);
+            Assert.AreEqual(ClassUnderTest._data[objName + "FloatProp"], testFloat);
+            ClassUnderTest._data.Count.Should().Be(5);
+            ClassUnderTest._data.ContainsKey(objName + "ComplexClass").Should().Be(false);
+            ClassUnderTest._data.ContainsKey(objName + "ComplexClass_NestedProperty").Should().Be(false);
+        }
+
+        [Test]
+        public void Can_map_object_with_dates()
+        {
+            string testString = "test";
+            int testInt = 32;
+            long testLong = 64L;
+            double testDouble = (double)2.0;
+            float testFloat = (float)3.0;
+            DateTime testDate = new DateTime(66, 6, 6);
+            DateTimeOffset testDateOffset = new DateTimeOffset(testDate, TimeSpan.FromHours(2));
+
+            var obj = new
+            {
+                StringProp = testString,
+                IntegerProp = testInt,
+                LongProp = testLong,
+                DoubleProp = testDouble,
+                FloatProp = testFloat,
+                ComplexClass = new
+                {
+                    NestedProperty = "Oh no!"
+                },
+                DateTimeProp = testDate,
+                DateTimeOffsetProp = testDateOffset
+            };
+            ClassUnderTest.Data(obj);
+            var objName = obj.GetType().Name + "_";
+            Assert.AreEqual(ClassUnderTest._data[objName + "StringProp"], testString);
+            Assert.AreEqual(ClassUnderTest._data[objName + "IntegerProp"], testInt);
+            Assert.AreEqual(ClassUnderTest._data[objName + "LongProp"], testLong);
+            Assert.AreEqual(ClassUnderTest._data[objName + "DoubleProp"], testDouble);
+            Assert.AreEqual(ClassUnderTest._data[objName + "FloatProp"], testFloat);
+            Assert.AreEqual(ClassUnderTest._data[objName + "DateTimeProp"], testDate);
+            Assert.AreEqual(ClassUnderTest._data[objName + "DateTimeOffsetProp"], testDateOffset);
+            ClassUnderTest._data.Count.Should().Be(7);
+            ClassUnderTest._data.ContainsKey(objName + "ComplexClass").Should().Be(false);
+            ClassUnderTest._data.ContainsKey(objName + "ComplexClass_NestedProperty").Should().Be(false);
+        }
+    }
+}

--- a/src/uShip.Logging.Tests/uShip.Logging.Tests.csproj
+++ b/src/uShip.Logging.Tests/uShip.Logging.Tests.csproj
@@ -74,6 +74,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="FluentLoggerDataBuilderTestscs.cs" />
     <Compile Include="HttpRequestExtensionsTests.cs" />
     <Compile Include="HttpRequestLoggingTests.cs" />
     <Compile Include="LoggerTests.cs" />

--- a/src/uShip.Logging/IFluentLoggerWriter.cs
+++ b/src/uShip.Logging/IFluentLoggerWriter.cs
@@ -54,6 +54,16 @@ namespace uShip.Logging
         /// <returns></returns>
         [Pure]
         [JetBrains.Annotations.Pure]
+        IFluentLoggerWriter Data(string name, object value);
+
+        /// <summary>
+        /// Fluent interface for adding data to a log.
+        /// </summary>
+        /// <param name="name">The key to be logged.</param>
+        /// <param name="value">The value to be logged.</param>
+        /// <returns></returns>
+        [Pure]
+        [JetBrains.Annotations.Pure]
         IFluentLoggerWriter Data(string name, string value);
 
         /// <summary>

--- a/src/uShip.Logging/LogBuilders/FluentLogDataBuilder.cs
+++ b/src/uShip.Logging/LogBuilders/FluentLogDataBuilder.cs
@@ -4,6 +4,8 @@ using log4net.Util;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using System.Web;
 using uShip.Logging.LogBuilders;
@@ -12,7 +14,7 @@ namespace uShip.Logging
 {
     public partial class Logger : ILogger
     {
-        private class FluentLogDataBuilder : IFluentLoggerWriter
+        internal class FluentLogDataBuilder : IFluentLoggerWriter
         {
             private readonly ILog _log;
             private readonly LoggingEventDataBuilder _loggingEventDataBuilder;
@@ -21,7 +23,7 @@ namespace uShip.Logging
             private Exception _exception;
             private string _sql;
             private IEnumerable<KeyValuePair<string, object>> _sqlParameters;
-            private readonly IDictionary<string, object> _data = new Dictionary<string, object>();
+            internal readonly IDictionary<string, object> _data = new Dictionary<string, object>();
             private readonly IList<string> _tags = new List<string>();
             private HttpRequestBase _request;
             private HttpResponseBase _response;
@@ -80,6 +82,108 @@ namespace uShip.Logging
             {
                 _exception = exception;
                 return this;
+            }
+
+            /// <summary>
+            /// Reflectively add non-complex properties (exceptions like DateTime and DateTimeOffset) from an object to the Data dictionary to be included in the logger's message.
+            /// </summary>
+            /// <param name="prefix">Prefix that will be prepended to the property key names in the data dictionary.</param>
+            /// <param name="value">Object/class that we are logging properties from.</param>
+            /// <returns></returns>
+            public IFluentLoggerWriter Data(string prefix, object value)
+            {
+                MapDataFromObject(prefix, value, true);
+                return this;
+            }
+
+            /// <summary>
+            /// Short-hand version of <see cref="Data(string,object)"/ of logging data from an object.
+            /// </summary>
+            /// <param name="value">Object's whose type will be used as the prefix to logging key name for all its properties.</param>
+            /// <returns></returns>
+            public IFluentLoggerWriter Data(object value)
+            {
+                var name = value.GetType().Name + '_';
+                return Data(name, value);
+            }
+
+            /// <summary>
+            /// Recursive method that adds properties of an object to the Data dictionary to be included in the logger's message.
+            /// </summary>
+            /// <param name="name"></param>
+            /// <param name="value"></param>
+            /// <param name="topLevel"></param>
+            private void MapDataFromObject(string name, object value, bool topLevel = false)
+            {
+                var type = value.GetType();        
+                if (topLevel)
+                {                    
+                    var props = type.GetProperties();
+                    //hard limit to 30 for now
+                    //TODO: Extend this to be dynamic.
+                    foreach (var prop in props.Take(30))
+                    {
+                        var propertyPrefixedName = name + prop.Name;
+                        //this seems really odd, but it is how you peel the properties's values off of the topLevel object. 
+                        var val = prop.GetValue(value, null);
+                        MapDataFromObject(propertyPrefixedName, val);
+                    }
+                    //we infer that this is definitely not a primitive and exit early. 
+                    return;
+                }
+                                
+                if (type.IsPrimitive
+                    || type == typeof(Decimal)
+                    || type == typeof(String)
+                    || type == typeof(DateTime)
+                    || type == typeof(DateTimeOffset)
+                    || type == typeof(TimeSpan)
+                    )
+                {
+                    
+                    //primitives
+                    if (type == typeof(String))
+                    {
+                        _data.Add(name, (String) value);
+                    }
+                    else if (type == typeof(int))
+                    {
+                        _data.Add(name, (int) value);
+                    }
+                    else if (type == typeof(long))
+                    {                       
+                        _data.Add(name, (long) value);
+                    }
+                    else if (type == typeof(float))
+                    {
+                        _data.Add(name, (float)value);
+                    }
+                    else if (type == typeof(double))
+                    {
+                        _data.Add(name, (double)value);
+                    }
+                    else if (type == typeof(Boolean))
+                    {
+                        _data.Add(name, (Boolean)value);
+                    }
+                    else if (type == typeof(Decimal))
+                    {
+                        _data.Add(name, (decimal)value);
+                    }
+                    //dates
+                    else if (type == typeof(DateTime))
+                    {
+                        _data.Add(name, (DateTime) value);
+                    }
+                    else if (type == typeof(DateTimeOffset))
+                    {
+                        _data.Add(name, (DateTimeOffset)value);
+                    }                   
+                    else if (type == typeof(DateTimeOffset))
+                    {
+                        _data.Add(name, (DateTimeOffset)value);
+                    }
+                }                              
             }
 
             public IFluentLoggerWriter Data(string name, string value)

--- a/src/uShip.Logging/LogBuilders/FluentLogDataBuilder.cs
+++ b/src/uShip.Logging/LogBuilders/FluentLogDataBuilder.cs
@@ -178,11 +178,7 @@ namespace uShip.Logging
                     else if (type == typeof(DateTimeOffset))
                     {
                         _data.Add(name, (DateTimeOffset)value);
-                    }                   
-                    else if (type == typeof(DateTimeOffset))
-                    {
-                        _data.Add(name, (DateTimeOffset)value);
-                    }
+                    }         
                 }                              
             }
 


### PR DESCRIPTION
Includes unit tests.

This extension allows us to add Data() properties by reflectively looping through simple properties. Because I'm lazy and "debug" logging shouldn't be so painful.

Hard coded limit of 30 properties per object mapped, this number can easily change, and I plan to let the caller control this.

Will not transverse complicated objects (this is shallow reflection).